### PR TITLE
Add basic prompt API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Server
 
 /server/target
+.idea
+/server/.idea
 
 # UI
 

--- a/server/Voxetta.iml
+++ b/server/Voxetta.iml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.11" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.3" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:javax.servlet-api:4.0.1" level="project" />
+    <orderEntry type="library" name="Maven: com.google.code.gson:gson:2.8.6" level="project" />
+    <orderEntry type="library" name="Maven: com.google.appengine:appengine-api-1.0-sdk:1.9.59" level="project" />
+  </component>
+</module>

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
@@ -16,10 +16,13 @@
 
 package com.google.speech.tools.voxetta.data;
 
+/**
+ * Client-facing schema for Prompts.
+ */
 public class Prompt {
 
     private final long id;
-//    private final VendorName;
+    //    private final VendorName;
 //    private final ProjectId;
     private final String type;
     private final String body;

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     https://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LCENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,6 +25,11 @@ public class Prompt {
     private final Type type;
     private final String body;
 
+    /**
+     * Determines the "type" of prompt and dictates what to expect in the prompt body.
+     * TEXT = body will be an excerpt to be read out
+     * IMAGE = body will be a URL to an image to be described
+     */
     enum Type {
         TEXT,
         IMAGE
@@ -32,19 +37,13 @@ public class Prompt {
 
     /**
      * @param id   {long} database ID of the prompt. param type {String} type of prompt.
+     * @param type {Type} type of prompt this is.
      * @param body {String} body (or content) of the prompt.
      */
-    public Prompt(long id, String type, String body) throws IllegalArgumentException {
+    public Prompt(long id, Type type, String body) throws IllegalArgumentException {
         this.id = id;
         this.body = body;
-
-        if (type.equalsIgnoreCase("text")) {
-            this.type = Type.TEXT;
-        } else if (type.equalsIgnoreCase("image")) {
-            this.type = Type.IMAGE;
-        } else {
-            throw new IllegalArgumentException("Prompt is incorrectly defined");
-        }
+        this.type = type;
     }
 
     /**
@@ -55,10 +54,10 @@ public class Prompt {
     }
 
     /**
-     * @return {String} type of the prompt.
+     * @return {Type} type of the prompt.
      */
-    public String getType() {
-        return type.toString();
+    public Type getType() {
+        return type;
     }
 
     /**
@@ -67,5 +66,4 @@ public class Prompt {
     public String getBody() {
         return body;
     }
-
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.data;
+
+public class Prompt {
+
+    private final long id;
+//    private final VendorName;
+//    private final ProjectId;
+    private final String type;
+    private final String body;
+
+    public Prompt(long id, String type, String body) {
+        this.id = id;
+        this.type = type;
+        this.body = body;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Prompt.java
@@ -22,25 +22,48 @@ package com.google.speech.tools.voxetta.data;
 public class Prompt {
 
     private final long id;
-    //    private final VendorName;
-//    private final ProjectId;
-    private final String type;
+    private final Type type;
     private final String body;
 
-    public Prompt(long id, String type, String body) {
-        this.id = id;
-        this.type = type;
-        this.body = body;
+    enum Type {
+        TEXT,
+        IMAGE
     }
 
+    /**
+     * @param id   {long} database ID of the prompt. param type {String} type of prompt.
+     * @param body {String} body (or content) of the prompt.
+     */
+    public Prompt(long id, String type, String body) throws IllegalArgumentException {
+        this.id = id;
+        this.body = body;
+
+        if (type.equalsIgnoreCase("text")) {
+            this.type = Type.TEXT;
+        } else if (type.equalsIgnoreCase("image")) {
+            this.type = Type.IMAGE;
+        } else {
+            throw new IllegalArgumentException("Prompt is incorrectly defined");
+        }
+    }
+
+    /**
+     * @return {long} database ID of the prompt.
+     */
     public long getId() {
         return id;
     }
 
+    /**
+     * @return {String} type of the prompt.
+     */
     public String getType() {
-        return type;
+        return type.toString();
     }
 
+    /**
+     * @return {String} body (or content) of the prompt.
+     */
     public String getBody() {
         return body;
     }

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
@@ -17,6 +17,7 @@
 package com.google.speech.tools.voxetta.data;
 
 import com.google.appengine.api.datastore.Entity;
+import com.google.speech.tools.voxetta.data.Prompt.Type;
 
 
 /**
@@ -25,7 +26,7 @@ import com.google.appengine.api.datastore.Entity;
 public class PromptBuilder {
 
     private long id;
-    private String type;
+    private Type type;
     private String body;
 
     public PromptBuilder() {
@@ -36,8 +37,16 @@ public class PromptBuilder {
         return this;
     }
 
-    public PromptBuilder setType(String type) {
-        this.type = type;
+    public PromptBuilder setType(String type) throws IllegalArgumentException {
+
+        if (type.equalsIgnoreCase("text")) {
+            this.type = Type.TEXT;
+        } else if (type.equalsIgnoreCase("image")) {
+            this.type = Type.IMAGE;
+        } else {
+            throw new IllegalArgumentException("Prompt is incorrectly defined");
+        }
+
         return this;
     }
 

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
@@ -18,6 +18,10 @@ package com.google.speech.tools.voxetta.data;
 
 import com.google.appengine.api.datastore.Entity;
 
+
+/**
+ * Builder pattern for Prompts.
+ */
 public class PromptBuilder {
 
     private long id;
@@ -42,6 +46,12 @@ public class PromptBuilder {
         return this;
     }
 
+    /**
+     * Builds a Prompt instance with the properties of a Prompt entity.
+     *
+     * @param entity Datastore entity.
+     * @return a Prompt instnace with the properties of the entity.
+     */
     public Prompt buildFromEntity(Entity entity) {
         return this
             .setId((long) entity.getKey().getId())

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.data;
+
+import com.google.appengine.api.datastore.Entity;
+
+public class PromptBuilder {
+
+    private long id;
+    private String type;
+    private String body;
+
+    public PromptBuilder() {
+    }
+
+    public PromptBuilder setId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public PromptBuilder setType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public PromptBuilder setBody(String body) {
+        this.body = body;
+        return this;
+    }
+
+    public Prompt buildFromEntity(Entity entity) {
+        return this
+            .setId((long) entity.getKey().getId())
+            .setType((String) entity.getProperty("type"))
+            .setBody((String) entity.getProperty("body"))
+            .build();
+    }
+
+    public Prompt build() {
+        return new Prompt(id, type, body);
+    }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/PromptBuilder.java
@@ -50,7 +50,7 @@ public class PromptBuilder {
      * Builds a Prompt instance with the properties of a Prompt entity.
      *
      * @param entity Datastore entity.
-     * @return a Prompt instnace with the properties of the entity.
+     * @return a Prompt instance with the properties of the entity.
      */
     public Prompt buildFromEntity(Entity entity) {
         return this

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptDebugService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptDebugService.java
@@ -1,0 +1,50 @@
+package com.google.speech.tools.voxetta.services;
+
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Query;
+import com.google.gson.Gson;
+import java.util.LinkedList;
+
+public class DatastorePromptDebugService {
+
+    private final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    private Gson gson = new Gson();
+
+    /**
+     * Retrieves all prompts in the database as Entities. Primarily for manual debugging.
+     *
+     * @return {String} JSON array of all Prompt Entities.
+     */
+    // TODO(eldrickb): change to StatusResponse object
+    public boolean resetAllToUnread() {
+
+        Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();
+
+        for (Entity entity : iterableResults) {
+            entity.setProperty("read", 0);
+            datastore.put(entity);
+        }
+
+        return true;
+    }
+
+    /**
+     * Resets the read status of all prompts to 0 so they can be used again. Primarily for manual
+     * debugging.
+     *
+     * @return a boolean denoting success or failure.
+     */
+    public String getAllPrompts() {
+
+        Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();
+
+        LinkedList<Entity> prompts = new LinkedList<Entity>();
+        for (Entity entity : iterableResults) {
+            prompts.add(entity);
+        }
+
+        return gson.toJson(prompts);
+    }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
@@ -47,6 +47,8 @@ public class DatastorePromptService implements PromptService {
     }
 
     @Override
+
+    // TODO: change to StatusResponse object
     public boolean savePrompt(String type, String body) {
 
         // TODO: validation
@@ -85,6 +87,7 @@ public class DatastorePromptService implements PromptService {
             return gson.toJson(unreadQueries);
         }
 
+        // TODO: transactionize
         Entity retrievedEntity = unreadQueries.get(0);
 
         // set prompt as read
@@ -96,11 +99,8 @@ public class DatastorePromptService implements PromptService {
         return gson.toJson(retrievedPrompt);
     }
 
-    /**
-     * Resets the read status of all prompts to 0 so they can be used again. Primarily for testing.
-     *
-     * @return a boolean denoting success or failure.
-     */
+    // TODO: change to StatusResponse object
+    @Override
     public boolean resetAllToUnread() {
 
         Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();
@@ -113,11 +113,7 @@ public class DatastorePromptService implements PromptService {
         return true;
     }
 
-    /**
-     * Returns all prompts as entities. Primarily for testing.
-     *
-     * @return JSON of all prompts as entities.
-     */
+    @Override
     public String getAllPrompts() {
 
         Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
@@ -46,13 +46,6 @@ public class DatastorePromptService implements PromptService {
     public DatastorePromptService() {
     }
 
-    /**
-     * Adds a prompt
-     *
-     * @param type Type of the prompt. Either "text" or "body".
-     * @param body The body of the prompt. Is either a phrase or image link.
-     * @return a boolean denoting success or failure.
-     */
     @Override
     public boolean savePrompt(String type, String body) {
 
@@ -78,6 +71,7 @@ public class DatastorePromptService implements PromptService {
      *
      * @return one prompt from the Prompt database.
      */
+    @Override
     public String getOnePrompt() {
 
         // get the prompt

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastorePromptService.java
@@ -48,11 +48,10 @@ public class DatastorePromptService implements PromptService {
 
     @Override
 
-    // TODO: change to StatusResponse object
+    // TODO(eldrickb): change to StatusResponse object
     public boolean savePrompt(String type, String body) {
 
-        // TODO: validation
-
+        // TODO(eldrickb): validation
         Entity promptEntity = new Entity("Prompt");
 
         promptEntity.setProperty("type", type);
@@ -87,7 +86,7 @@ public class DatastorePromptService implements PromptService {
             return gson.toJson(unreadQueries);
         }
 
-        // TODO: transactionize
+        // TODO(eldrickb): transactionize
         Entity retrievedEntity = unreadQueries.get(0);
 
         // set prompt as read
@@ -97,32 +96,5 @@ public class DatastorePromptService implements PromptService {
         // return the prompt as JSON
         Prompt retrievedPrompt = new PromptBuilder().buildFromEntity(retrievedEntity);
         return gson.toJson(retrievedPrompt);
-    }
-
-    // TODO: change to StatusResponse object
-    @Override
-    public boolean resetAllToUnread() {
-
-        Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();
-
-        for (Entity entity : iterableResults) {
-            entity.setProperty("read", 0);
-            datastore.put(entity);
-        }
-
-        return true;
-    }
-
-    @Override
-    public String getAllPrompts() {
-
-        Iterable<Entity> iterableResults = datastore.prepare(new Query("Prompt")).asIterable();
-
-        LinkedList<Entity> prompts = new LinkedList<Entity>();
-        for (Entity entity : iterableResults) {
-            prompts.add(entity);
-        }
-
-        return gson.toJson(prompts);
     }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.services;
+
+public interface PromptService {
+
+    public boolean savePrompt(String type, String body);
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
@@ -16,7 +16,24 @@
 
 package com.google.speech.tools.voxetta.services;
 
+/**
+ * Outlines functions necessary to implement the Prompt Service.
+ */
 public interface PromptService {
-
+    
+    /**
+     * Adds a prompt to the database.
+     *
+     * @param type Type of the prompt. Either "text" or "body".
+     * @param body The body of the prompt. Is either a phrase or image link.
+     * @return a boolean denoting success or failure.
+     */
     public boolean savePrompt(String type, String body);
+
+    /**
+     * Retrieves one prompt from the database.
+     *
+     * @return one prompt from the Prompt database.
+     */
+    public String getOnePrompt();
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
@@ -38,20 +38,4 @@ public interface PromptService {
      * @return one prompt from the Prompt database.
      */
     public String getOnePrompt();
-
-    /**
-     * Retrieves all prompts in the database as Entities. Primarily for manual debugging.
-     *
-     * @return {String} JSON array of all Prompt Entities.
-     */
-    public String getAllPrompts();
-
-
-    /**
-     * Resets the read status of all prompts to 0 so they can be used again. Primarily for manual
-     * debugging.
-     *
-     * @return a boolean denoting success or failure.
-     */
-    public boolean resetAllToUnread();
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/PromptService.java
@@ -20,7 +20,7 @@ package com.google.speech.tools.voxetta.services;
  * Outlines functions necessary to implement the Prompt Service.
  */
 public interface PromptService {
-    
+
     /**
      * Adds a prompt to the database.
      *
@@ -28,6 +28,8 @@ public interface PromptService {
      * @param body The body of the prompt. Is either a phrase or image link.
      * @return a boolean denoting success or failure.
      */
+
+    // TODO: change to StatusResponse object
     public boolean savePrompt(String type, String body);
 
     /**
@@ -36,4 +38,20 @@ public interface PromptService {
      * @return one prompt from the Prompt database.
      */
     public String getOnePrompt();
+
+    /**
+     * Retrieves all prompts in the database as Entities. Primarily for manual debugging.
+     *
+     * @return {String} JSON array of all Prompt Entities.
+     */
+    public String getAllPrompts();
+
+
+    /**
+     * Resets the read status of all prompts to 0 so they can be used again. Primarily for manual
+     * debugging.
+     *
+     * @return a boolean denoting success or failure.
+     */
+    public boolean resetAllToUnread();
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
@@ -16,6 +16,7 @@
 
 package com.google.speech.tools.voxetta.servlets;
 
+import com.google.speech.tools.voxetta.services.PromptService;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -26,16 +27,33 @@ import static com.google.speech.tools.voxetta.utils.ParamParser.getParameter;
 
 import com.google.speech.tools.voxetta.services.DatastorePromptService;
 
+/**
+ * Servlet for seeing / resetting all prompts; used for manual debugging for now
+ */
 @WebServlet("/prompt/all")
 public class AllPromptsServlet extends HttpServlet {
 
-    private final DatastorePromptService promptService = new DatastorePromptService();
+    private final PromptService promptService = new DatastorePromptService();
 
+    /**
+     * gets all prompts via PromptService.getAllPrompts()
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.getWriter().write(promptService.getAllPrompts());
     }
 
+    /**
+     * resets the read status of all prompts.
+     *
+     * @param request
+     * @param response
+     * @throws IOException
+     */
     @Override
     public void doPost(HttpServletRequest request, HttpServletResponse response)
         throws IOException {

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.google.speech.tools.voxetta.utils.ParamParser.getParameter;
+
+import com.google.speech.tools.voxetta.services.DatastorePromptService;
+
+@WebServlet("/prompt/all")
+public class AllPromptsServlet extends HttpServlet {
+
+    private final DatastorePromptService promptService = new DatastorePromptService();
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.getWriter().write(promptService.getAllPrompts());
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+        response.getWriter().write(String.valueOf(promptService.resetAllToUnread()));
+    }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/AllPromptsServlet.java
@@ -16,7 +16,7 @@
 
 package com.google.speech.tools.voxetta.servlets;
 
-import com.google.speech.tools.voxetta.services.PromptService;
+import com.google.speech.tools.voxetta.services.DatastorePromptDebugService;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -33,7 +33,7 @@ import com.google.speech.tools.voxetta.services.DatastorePromptService;
 @WebServlet("/prompt/all")
 public class AllPromptsServlet extends HttpServlet {
 
-    private final PromptService promptService = new DatastorePromptService();
+    private final DatastorePromptDebugService promptService = new DatastorePromptDebugService();
 
     /**
      * gets all prompts via PromptService.getAllPrompts()

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
@@ -38,12 +38,7 @@ public class PromptServlet extends HttpServlet {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        try {
-            response.getWriter().write(promptService.getOnePrompt());
-        } catch (IOException e) {
-            response.setStatus(500);
-            response.getWriter().write("false");
-        }
+        response.getWriter().write(promptService.getOnePrompt());
     }
 
     @Override
@@ -55,7 +50,7 @@ public class PromptServlet extends HttpServlet {
 
         String boolResp = Boolean.toString(promptService.savePrompt(type, body));
 
-        // TODO: use StatusResponse
+        // TODO(eldrickb): use StatusResponse
         response.getWriter().write(boolResp);
     }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
@@ -16,6 +16,7 @@
 
 package com.google.speech.tools.voxetta.servlets;
 
+import com.google.speech.tools.voxetta.services.PromptService;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -32,12 +33,17 @@ import com.google.speech.tools.voxetta.services.DatastorePromptService;
 @WebServlet("/prompt")
 public class PromptServlet extends HttpServlet {
 
-    private final DatastorePromptService promptService = new DatastorePromptService();
+    private final PromptService promptService = new DatastorePromptService();
 
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
 
-        response.getWriter().write(promptService.getOnePrompt());
+        try {
+            response.getWriter().write(promptService.getOnePrompt());
+        } catch (IOException e) {
+            response.setStatus(500);
+            response.getWriter().write("false");
+        }
     }
 
     @Override
@@ -49,6 +55,7 @@ public class PromptServlet extends HttpServlet {
 
         String boolResp = Boolean.toString(promptService.savePrompt(type, body));
 
+        // TODO: use StatusResponse
         response.getWriter().write(boolResp);
     }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/PromptServlet.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.servlets;
+
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import static com.google.speech.tools.voxetta.utils.ParamParser.getParameter;
+
+import com.google.speech.tools.voxetta.services.DatastorePromptService;
+
+/**
+ * Servlet that handles the  "/prompt" endpoint
+ */
+@WebServlet("/prompt")
+public class PromptServlet extends HttpServlet {
+
+    private final DatastorePromptService promptService = new DatastorePromptService();
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+
+        response.getWriter().write(promptService.getOnePrompt());
+    }
+
+    @Override
+    public void doPost(HttpServletRequest request, HttpServletResponse response)
+        throws IOException {
+
+        final String type = getParameter(request, "type", "");
+        final String body = getParameter(request, "body", "");
+
+        String boolResp = Boolean.toString(promptService.savePrompt(type, body));
+
+        response.getWriter().write(boolResp);
+    }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/utils/ParamParser.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/utils/ParamParser.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.speech.tools.voxetta.utils;
+
+import javax.servlet.http.HttpServletRequest;
+
+import java.util.Optional;
+
+/**
+ * Utility class to retrieve a param for a request and/or return a default
+ */
+public class ParamParser {
+
+    /**
+     * @return the request parameter, or the default value if the parameter is not found in the
+     * request.
+     */
+    public static String getParameter(HttpServletRequest request, String name,
+        String defaultValue) {
+        return Optional.ofNullable(request.getParameter(name)).orElse(defaultValue);
+    }
+}


### PR DESCRIPTION
Adds a basic implementation of the prompt API.

- Supports submitting prompts and retrieving one from `/prompt`
  - When a prompt is created, it has a `read` property attached with a value of 0. 
  - Prompts are retrieved by getting the first prompt with `{ read: 0 }`. `read` is updated to 1 before it's sent back as JSON. 
- Also added `/prompt/all` endpoint
  - GET: returns all prompts as entities, was useful for me at some points but not currently, should remove?
  - POST: set the `read` property of all prompts to 0.
- Added a util package, and a ParamParser class to easily parse params from requests (stolen from the STEP repo)

Also, since this is technically ahead of time (I estimated to have this by end of day tomorrow) I could probably add testing tomorrow? or move on to the prompt UI?