### PR TITLE
Refactor Utterance Services to Return Response Objects

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -44,6 +44,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>29.0-jre</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>4.0.1</version>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -15,10 +15,33 @@
 
     <dependencies>
         <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.11</version>
-          <scope>test</scope>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-labs</artifactId>
+            <version>1.9.60</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-1.0-sdk</artifactId>
+            <version>1.9.59</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-stubs</artifactId>
+            <version>1.9.60</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-testing</artifactId>
+            <version>1.9.60</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-tools-sdk</artifactId>
+            <version>1.9.60</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
@@ -27,16 +50,15 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.11</version>
+          <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>2.8.6</version>
-        </dependency>
-
-        <!-- TODO(eldrickb): is this the correct version? -->
-        <dependency>
-            <groupId>com.google.appengine</groupId>
-            <artifactId>appengine-api-1.0-sdk</artifactId>
-            <version>1.9.59</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.google.sps</groupId>
+    <groupId>com.google.speech.tools.voxetta</groupId>
     <artifactId>Voxetta</artifactId>
     <version>1</version>
     <packaging>war</packaging>
@@ -37,6 +37,12 @@
             <groupId>com.google.appengine</groupId>
             <artifactId>appengine-api-1.0-sdk</artifactId>
             <version>1.9.59</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>2.17.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/ErrorResponse.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/ErrorResponse.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.data;
+
+/** 
+ * An ErrorResponse is the container for a servlet's response to a front-end fetch request upon failure.  
+ */
+public class ErrorResponse extends StatusResponse {
+ 
+  private String error; 
+
+  /**
+   * Creates a new ErrorResponse.
+   *
+   * @param success Represents if a backend fetch was successful or not. 
+   * @param error The error message associated with a given failure.
+   */ 
+  public ErrorResponse(boolean success, String error) {
+    super(success);
+    this.error = error;
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/StatusResponse.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/StatusResponse.java
@@ -35,9 +35,8 @@ public class StatusResponse {
   /** 
    * Returns a JSON representation of a StatusResponse.  
    */
-  public static String convertToJson(StatusResponse response) {
+  public String toJson() {
     Gson gson = new Gson();
-    String json = gson.toJson(response);
-    return json;
+    return gson.toJson(this);
   }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/StatusResponse.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/StatusResponse.java
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.data;
+
+import com.google.gson.Gson;
+
+/** 
+ * A StatusResponse is the container for a servlet's response to a front-end fetch request.  
+ */
+public class StatusResponse {
+  
+  private boolean success;
+
+  /**
+   * Creates a new StatusResponse.
+   *
+   * @param success Represents if a backend fetch was successful or not. 
+   */ 
+  public StatusResponse(boolean success) {
+    this.success = success;
+  }
+
+  /** 
+   * Returns a JSON representation of a StatusResponse.  
+   */
+  public static String convertToJson(StatusResponse response) {
+    Gson gson = new Gson();
+    String json = gson.toJson(response);
+    return json;
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/UrlResponse.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/UrlResponse.java
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.data;
+
+/** 
+ * A UrlResponse is the container for a servlet's response to a front-end fetch request for a URL.  
+ */
+public class UrlResponse extends StatusResponse {
+  
+  private String url; 
+
+  /**
+   * Creates a new ErrorResponse.
+   *
+   * @param success Represents if a backend fetch was successful or not. 
+   * @param error The error message associated with a given failure.
+   */ 
+  public UrlResponse(boolean success, String url) {
+    super(success);
+    this.url = url;
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Utterance.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Utterance.java
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.data;
+
+/** 
+ * An Utterance is the container for a speaker's verbal response to a given prompt.  
+ */
+public final class Utterance {
+
+  private String audio;
+  private String userId;
+  private String promptId;
+  private String device; 
+  private int age;
+  private String gender; 
+
+  /**
+   * Creates a new Utterance.
+   *
+   * @param audio The reference to the audio file. Must be non-null.
+   * @param userId The id of the speaker. Must be non-null.
+   * @param promptId The id of the prompt the audio file is responding to. Must be non-null.
+   * @param device The name of the device the speaker is using to record audio files. Must be non-null.
+   * @param age The age of the speaker. Must be a positive integer between 1 and 120, inclusive. 
+   * @param gender The gender of the speaker. Must be non-null.
+   */
+  public Utterance(String audio, String userId, String promptId, String device, int age, String gender) {
+    verifyConstructorLegality(audio, userId, promptId, device, age, gender);
+
+    this.audio = audio; 
+    this.userId = userId; 
+    this.promptId = promptId;
+    this.device = device; 
+    this.age = age; 
+    this.gender = gender; 
+  }
+
+  // Ensure the legality of the Utterance constructor's arguments
+  private void verifyConstructorLegality(String audio, String userId, String promptId, String device, int age, String gender) {
+    // Ensure no applicable argument is null
+    if (audio == null) { throw new IllegalArgumentException("audio cannot be null"); }
+    if (userId == null) { throw new IllegalArgumentException("userId cannot be null"); }
+    if (promptId == null) { throw new IllegalArgumentException("promptId cannot be null"); }
+    if (device == null) { throw new IllegalArgumentException("device cannot be null"); }
+    if (gender == null) { throw new IllegalArgumentException("gender cannot be null"); }
+
+    // Ensure age is between 1 and 120, inclusive
+    if (!(1 <= age && age <= 120)) { throw new IllegalArgumentException("age must be between 1 and 120, inclusive"); }
+  }
+
+  /**
+   * Return the reference to the audio file.
+   */
+  public String getAudio() {
+    return audio;
+  }
+
+  /**
+   * Return the id of the speaker.
+   */
+  public String getUserId() {
+    return userId;
+  }
+
+  /**
+   * Return the id of the prompt the audio file is responding to.
+   */
+  public String getPromptId() {
+    return promptId;
+  }
+
+  /**
+   * Return the name of the device the speaker is using to record audio files.
+   */
+  public String getDevice() {
+    return device;
+  }
+
+  /**
+   * Return the age of the speaker.
+   */
+  public int getAge() {
+    return age;
+  }
+
+  /**
+   * Return gender of the speaker.
+   */
+  public String getGender() {
+    return gender;
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/data/Utterance.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/data/Utterance.java
@@ -19,6 +19,9 @@ package com.google.speech.tools.voxetta.data;
  */
 public final class Utterance {
 
+  private static final int MIN_ALLOWED_AGE = 1;
+  private static final int MAX_ALLOWED_AGE = 120;
+
   private String audio;
   private String userId;
   private String promptId;
@@ -35,20 +38,20 @@ public final class Utterance {
    * @param device The name of the device the speaker is using to record audio files. Must be non-null.
    * @param age The age of the speaker. Must be a positive integer between 1 and 120, inclusive. 
    * @param gender The gender of the speaker. Must be non-null.
-   */
+   */ 
   public Utterance(String audio, String userId, String promptId, String device, int age, String gender) {
-    verifyConstructorLegality(audio, userId, promptId, device, age, gender);
-
     this.audio = audio; 
     this.userId = userId; 
     this.promptId = promptId;
     this.device = device; 
     this.age = age; 
     this.gender = gender; 
+
+    verifyConstructorLegality();
   }
 
   // Ensure the legality of the Utterance constructor's arguments
-  private void verifyConstructorLegality(String audio, String userId, String promptId, String device, int age, String gender) {
+  private void verifyConstructorLegality() {
     // Ensure no applicable argument is null
     if (audio == null) { throw new IllegalArgumentException("audio cannot be null"); }
     if (userId == null) { throw new IllegalArgumentException("userId cannot be null"); }
@@ -57,7 +60,7 @@ public final class Utterance {
     if (gender == null) { throw new IllegalArgumentException("gender cannot be null"); }
 
     // Ensure age is between 1 and 120, inclusive
-    if (!(1 <= age && age <= 120)) { throw new IllegalArgumentException("age must be between 1 and 120, inclusive"); }
+    if (!(MIN_ALLOWED_AGE <= age && age <= MAX_ALLOWED_AGE)) { throw new IllegalArgumentException("age must be between 1 and 120, inclusive"); }
   }
 
   /**
@@ -96,9 +99,78 @@ public final class Utterance {
   }
 
   /**
-   * Return gender of the speaker.
+   * Return the gender of the speaker.
    */
   public String getGender() {
     return gender;
+  }
+
+  /**
+   * A builder for the Utterance object. 
+   */
+  public static class UtteranceBuilder {
+    private String audio;
+    private String userId;
+    private String promptId;
+    private String device; 
+    private int age;
+    private String gender; 
+
+    public UtteranceBuilder() {}
+
+    /**
+     * Set the reference to the audio file.
+     */
+    public UtteranceBuilder setAudio(String audio) {
+      this.audio = audio;
+      return this;
+    }
+
+    /**
+     * Set the id of the speaker.
+     */
+    public UtteranceBuilder setUserId(String userId) {
+      this.userId = userId;
+      return this;
+    }
+
+    /**
+     * Set the id of the prompt the audio file is responding to.
+     */
+    public UtteranceBuilder setPromptId(String promptId) {
+      this.promptId = promptId;
+      return this;
+    }
+
+    /**
+     * Set the name of the device the speaker is using to record audio files.
+     */
+    public UtteranceBuilder setDevice(String device) {
+      this.device = device;
+      return this;
+    }
+
+    /**
+     * Set the age of the speaker.
+     */
+    public UtteranceBuilder setAge(int age) {
+      this.age = age;
+      return this;
+    }
+
+    /**
+     * Set the gender of the speaker.
+     */
+    public UtteranceBuilder setGender(String gender) {
+      this.gender = gender;
+      return this;
+    }
+
+    /**
+     * Return a newly built Utterance.
+     */
+    public Utterance build() {
+      return new Utterance(this.userId, this.audio, this.promptId, this.device, this.age, this.gender);
+    }
   }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
@@ -22,6 +22,7 @@ import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.common.annotations.VisibleForTesting; 
 import com.google.speech.tools.voxetta.data.Utterance; 
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ public class DatastoreUtteranceService implements UtteranceService {
   private DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
   private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
 
+  @Override 
   public void saveUtterance(Utterance utterance) {
     // Create and initialize a new Utterance Entity
     Entity utteranceEntity = new Entity("Utterance");
@@ -49,10 +51,8 @@ public class DatastoreUtteranceService implements UtteranceService {
     // Store the Utterance Entity in Datastore 
     datastoreService.put(utteranceEntity); 
   }
-
-  /** 
-   * Returns the BlobKey of the just-uploaded audio file. 
-   */
+  
+  @Override
   public String getAudio(HttpServletRequest request) {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("audio");
@@ -66,9 +66,7 @@ public class DatastoreUtteranceService implements UtteranceService {
     return blobKeys.get(0).getKeyString();
   }
 
-  /** 
-   * Return a Blobstore Upload URL that redirects to the Utterance Upload Servlet.
-   */
+  @Override
   public String getFormUrl() {
     return blobstoreService.createUploadUrl("/upload-utterance"); 
   }
@@ -76,6 +74,7 @@ public class DatastoreUtteranceService implements UtteranceService {
   /** 
    * Allow the servlet's Datastore service to be set for mocking purposes.
    */
+  @VisibleForTesting
   public void setDatastoreService(DatastoreService inputService) {
     datastoreService = inputService; 
   }
@@ -83,6 +82,7 @@ public class DatastoreUtteranceService implements UtteranceService {
   /** 
    * Allow the servlet's Blobstore service to be set for mocking purposes.
    */
+  @VisibleForTesting
   public void setBlobstoreService(BlobstoreService inputService) {
     blobstoreService = inputService; 
   }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
@@ -1,0 +1,89 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.services;
+
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import com.google.speech.tools.voxetta.data.Utterance; 
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+
+/** 
+ * Functionality for uploading audio files to Blobstore & uploading the related Utterance
+ * object to Datastore.  
+ */
+public class DatastoreUtteranceService implements UtteranceService {
+  
+  private DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+  private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+
+  public void saveUtterance(Utterance utterance) {
+    // Create and initialize a new Utterance Entity
+    Entity utteranceEntity = new Entity("Utterance");
+    utteranceEntity.setProperty("audioKey", utterance.getAudio());
+    utteranceEntity.setProperty("userId", utterance.getUserId());
+    utteranceEntity.setProperty("promptId", utterance.getPromptId());
+    utteranceEntity.setProperty("device", utterance.getDevice());
+    utteranceEntity.setProperty("age", utterance.getAge());
+    utteranceEntity.setProperty("gender", utterance.getGender());
+    
+    // Store the Utterance Entity in Datastore 
+    datastoreService.put(utteranceEntity); 
+  }
+
+  /** 
+   * Returns the BlobKey of the just-uploaded audio file. 
+   */
+  public String getAudio(HttpServletRequest request) {
+    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+    List<BlobKey> blobKeys = blobs.get("audio");
+
+    // Return null if an audio file was not uploaded
+    if (blobKeys == null || blobKeys.isEmpty()) {
+      return null; 
+    }
+ 
+    // Return the BlobKey of the uploaded file
+    return blobKeys.get(0).getKeyString();
+  }
+
+  /** 
+   * Return a Blobstore Upload URL that redirects to the Utterance Upload Servlet.
+   */
+  public String getFormUrl() {
+    return blobstoreService.createUploadUrl("/upload-utterance"); 
+  }
+
+  /** 
+   * Allow the servlet's Datastore service to be set for mocking purposes.
+   */
+  public void setDatastoreService(DatastoreService inputService) {
+    datastoreService = inputService; 
+  }
+
+  /** 
+   * Allow the servlet's Blobstore service to be set for mocking purposes.
+   */
+  public void setBlobstoreService(BlobstoreService inputService) {
+    blobstoreService = inputService; 
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceService.java
@@ -53,7 +53,7 @@ public class DatastoreUtteranceService implements UtteranceService {
   }
   
   @Override
-  public String getAudio(HttpServletRequest request) {
+  public String getAudioBlob(HttpServletRequest request) {
     Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
     List<BlobKey> blobKeys = blobs.get("audio");
 
@@ -67,7 +67,7 @@ public class DatastoreUtteranceService implements UtteranceService {
   }
 
   @Override
-  public String getFormUrl() {
+  public String getAudioBlobUploadUrl() {
     return blobstoreService.createUploadUrl("/upload-utterance"); 
   }
 

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
@@ -33,10 +33,10 @@ public interface UtteranceService {
   /** 
    * Returns a reference to the just-uploaded audio file. 
    */
-  public String getAudio(HttpServletRequest request);
+  public String getAudioBlob(HttpServletRequest request);
 
   /** 
    * Return an upload URL that redirects to the Utterance Upload Servlet.
    */
-  public String getFormUrl(); 
+  public String getAudioBlobUploadUrl(); 
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
@@ -14,7 +14,11 @@
 
 package com.google.speech.tools.voxetta.services;
 
-import com.google.speech.tools.voxetta.data.Utterance; 
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.common.annotations.VisibleForTesting; 
+import com.google.speech.tools.voxetta.data.Utterance;
+import javax.servlet.http.HttpServletRequest; 
 
 /** 
  * Functionality necessary to successfully upload Utterances to an external database.   
@@ -25,4 +29,14 @@ public interface UtteranceService {
    * Saves an Utterance to an external database.  
    */
   public void saveUtterance(Utterance utterance);
+
+  /** 
+   * Returns a reference to the just-uploaded audio file. 
+   */
+  public String getAudio(HttpServletRequest request);
+
+  /** 
+   * Return an upload URL that redirects to the Utterance Upload Servlet.
+   */
+  public String getFormUrl(); 
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/services/UtteranceService.java
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.services;
+
+import com.google.speech.tools.voxetta.data.Utterance; 
+
+/** 
+ * Functionality necessary to successfully upload Utterances to an external database.   
+ */
+public interface UtteranceService {
+
+  /** 
+   * Saves an Utterance to an external database.  
+   */
+  public void saveUtterance(Utterance utterance);
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -42,11 +42,11 @@ public class BlobstoreLinkServlet extends HttpServlet {
     // Create and return a Blobstore Upload URL  
     try {
       String uploadUrl = service.getAudioBlobUploadUrl();
-      String successJson = StatusResponse.convertToJson(new UrlResponse(true, uploadUrl));
+      String successJson = new UrlResponse(true, uploadUrl).toJson();
       response.getWriter().println(successJson); 
     } catch (BlobstoreFailureException e) {
-      String failureJson = ErrorResponse.convertToJson(
-          new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore."));
+      String failureJson = 
+          new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore.").toJson();
       response.getWriter().println(failureJson);
     }
   }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -41,7 +41,7 @@ public class BlobstoreLinkServlet extends HttpServlet {
 
     // Create and return a Blobstore Upload URL  
     try {
-      String uploadUrl = service.getFormUrl();
+      String uploadUrl = service.getAudioBlobUploadUrl();
       String successJson = StatusResponse.convertToJson(new UrlResponse(true, uploadUrl));
       response.getWriter().println(successJson); 
     } catch (BlobstoreFailureException e) {

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+ 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+ 
+//     https://www.apache.org/licenses/LICENSE-2.0
+ 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
+package com.google.speech.tools.voxetta;
+ 
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import java.io.IOException;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+ 
+/** 
+* Servlet that returns a Blobstore URL. 
+*/
+@WebServlet("/blobstore-link")
+public class BlobstoreLinkServlet extends HttpServlet {
+ 
+  private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+ 
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    // Redirect to Datastore processing after Blobstore processing
+    String uploadUrl = blobstoreService.createUploadUrl("/upload-utterance");
+ 
+    response.setContentType("text/html");
+    response.getWriter().println(uploadUrl);
+  }
+
+  /** 
+  * Allow the servlet's Blobstore service to be set for mocking purposes
+  */
+  public void setBlobstoreService(BlobstoreService inputService) {
+      blobstoreService = inputService; 
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -16,6 +16,9 @@ package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.blobstore.BlobstoreFailureException;
 import com.google.common.annotations.VisibleForTesting; 
+import com.google.speech.tools.voxetta.data.ErrorResponse;
+import com.google.speech.tools.voxetta.data.StatusResponse;
+import com.google.speech.tools.voxetta.data.UrlResponse; 
 import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
 import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.IOException;
@@ -39,10 +42,12 @@ public class BlobstoreLinkServlet extends HttpServlet {
     // Create and return a Blobstore Upload URL  
     try {
       String uploadUrl = service.getFormUrl();
-      response.getWriter().println("{ \"success\": true, \"url\": \"" + uploadUrl + "\" }"); 
+      String successJson = StatusResponse.convertToJson(new UrlResponse(true, uploadUrl));
+      response.getWriter().println(successJson); 
     } catch (BlobstoreFailureException e) {
-      // TO DO (ASHLEY): refactor JSON in future pr
-      response.getWriter().println("{ \"success\": false, \"error\": \"Error: Failed to upload audio file to Blobstore.\" }");
+      String failureJson = ErrorResponse.convertToJson(
+          new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore."));
+      response.getWriter().println(failureJson);
     }
   }
 

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -15,7 +15,9 @@
 package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.blobstore.BlobstoreFailureException;
+import com.google.common.annotations.VisibleForTesting; 
 import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
+import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -28,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
 @WebServlet("/blobstore-utterance-upload-link")
 public class BlobstoreLinkServlet extends HttpServlet {
 
-  private DatastoreUtteranceService service = new DatastoreUtteranceService(); 
+  private UtteranceService service = new DatastoreUtteranceService(); 
  
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -39,6 +41,7 @@ public class BlobstoreLinkServlet extends HttpServlet {
       String uploadUrl = service.getFormUrl();
       response.getWriter().println("{ \"success\": true, \"url\": \"" + uploadUrl + "\" }"); 
     } catch (BlobstoreFailureException e) {
+      // TO DO (ASHLEY): refactor JSON in future pr
       response.getWriter().println("{ \"success\": false, \"error\": \"Error: Failed to upload audio file to Blobstore.\" }");
     }
   }
@@ -46,7 +49,8 @@ public class BlobstoreLinkServlet extends HttpServlet {
   /** 
    * Allow the servlet's Datastore Utterance Service to be set for mocking purposes.
    */
-  public void setService(DatastoreUtteranceService inputService) {
+  @VisibleForTesting
+  public void setService(UtteranceService inputService) {
     service = inputService; 
   }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServlet.java
@@ -1,21 +1,21 @@
 // Copyright 2020 Google LLC
- 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
- 
+// 
 //     https://www.apache.org/licenses/LICENSE-2.0
- 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
  
-package com.google.speech.tools.voxetta;
- 
-import com.google.appengine.api.blobstore.BlobstoreService;
-import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+package com.google.speech.tools.voxetta.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreFailureException;
+import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
 import java.io.IOException;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
@@ -23,26 +23,30 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
  
 /** 
-* Servlet that returns a Blobstore URL. 
-*/
-@WebServlet("/blobstore-link")
+ * Servlet that returns a Blobstore URL. 
+ */
+@WebServlet("/blobstore-utterance-upload-link")
 public class BlobstoreLinkServlet extends HttpServlet {
- 
-  private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+
+  private DatastoreUtteranceService service = new DatastoreUtteranceService(); 
  
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
-    // Redirect to Datastore processing after Blobstore processing
-    String uploadUrl = blobstoreService.createUploadUrl("/upload-utterance");
- 
-    response.setContentType("text/html");
-    response.getWriter().println(uploadUrl);
+    response.setContentType("application/json");
+
+    // Create and return a Blobstore Upload URL  
+    try {
+      String uploadUrl = service.getFormUrl();
+      response.getWriter().println("{ \"success\": true, \"url\": \"" + uploadUrl + "\" }"); 
+    } catch (BlobstoreFailureException e) {
+      response.getWriter().println("{ \"success\": false, \"error\": \"Error: Failed to upload audio file to Blobstore.\" }");
+    }
   }
 
   /** 
-  * Allow the servlet's Blobstore service to be set for mocking purposes
-  */
-  public void setBlobstoreService(BlobstoreService inputService) {
-      blobstoreService = inputService; 
+   * Allow the servlet's Datastore Utterance Service to be set for mocking purposes.
+   */
+  public void setService(DatastoreUtteranceService inputService) {
+    service = inputService; 
   }
 }

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
@@ -1,0 +1,91 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
+package com.google.speech.tools.voxetta;
+ 
+import com.google.appengine.api.blobstore.BlobInfo;
+import com.google.appengine.api.blobstore.BlobInfoFactory;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobstoreServiceFactory;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
+import com.google.appengine.api.datastore.Entity;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+ 
+/** Servlet that handles Utterance Entities. */
+@WebServlet("/upload-utterance")
+public class UtteranceUploadServlet extends HttpServlet {
+ 
+  private DatastoreService datastoreService = DatastoreServiceFactory.getDatastoreService();
+  private BlobstoreService blobstoreService = BlobstoreServiceFactory.getBlobstoreService();
+ 
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+ 
+    // Get the URL of the audio file that has been uploaded to Blobstore
+    String audioKey = getUploadedFileKey(request, "audio");
+    
+    Entity utteranceEntity = new Entity("Utterance");
+    utteranceEntity.setProperty("audioKey", audioKey);
+    utteranceEntity.setProperty("userId", "FILLER");
+    utteranceEntity.setProperty("promptId", "FILLER");
+    utteranceEntity.setProperty("device", "FILLER");
+    utteranceEntity.setProperty("age", 100);
+    utteranceEntity.setProperty("gender", "FILLER");
+    
+    // Store the Utterance Entity in Datastore 
+    datastoreService.put(utteranceEntity);
+ 
+    // Redirect back to the main recording page
+    response.sendRedirect("/index.html");
+  }
+ 
+  // Returns the BlobKey of an uploaded file, or null if a file was not uploaded
+  private String getUploadedFileKey(HttpServletRequest request, String formInputElementName) {
+    Map<String, List<BlobKey>> blobs = blobstoreService.getUploads(request);
+    List<BlobKey> blobKeys = blobs.get(formInputElementName);
+
+    // Return null if an audio file was not uploaded
+    if (blobKeys == null || blobKeys.isEmpty()) {
+      return null; 
+    }
+ 
+    // Return the BlobKey of the uploaded file
+    return blobKeys.get(0).getKeyString();
+  }
+
+  /** 
+  * Allow the servlet's Datastore service to be set for mocking purposes
+  */
+  public void setDatastoreService(DatastoreService inputService) {
+      datastoreService = inputService; 
+  }
+
+  /** 
+  * Allow the servlet's Blobstore service to be set for mocking purposes
+  */
+  public void setBlobstoreService(BlobstoreService inputService) {
+      blobstoreService = inputService; 
+  }
+}

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
@@ -43,7 +43,7 @@ public class UtteranceUploadServlet extends HttpServlet {
     response.setContentType("application/json");
 
     // Get the BlobKey of the audio file that has been uploaded to Blobstore
-    audio = service.getAudio(request);
+    audio = service.getAudioBlob(request);
 
     // Create and save Utterance to Datastore
     Utterance utterance = new Utterance.UtteranceBuilder()

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
@@ -18,6 +18,8 @@ import com.google.appengine.api.blobstore.BlobstoreFailureException;
 import com.google.appengine.api.datastore.DatastoreFailureException;
 import com.google.common.annotations.VisibleForTesting; 
 import com.google.speech.tools.voxetta.data.Utterance; 
+import com.google.speech.tools.voxetta.data.ErrorResponse;
+import com.google.speech.tools.voxetta.data.StatusResponse; 
 import com.google.speech.tools.voxetta.services.DatastoreUtteranceService; 
 import com.google.speech.tools.voxetta.services.UtteranceService; 
 import java.io.IOException;
@@ -33,6 +35,7 @@ import javax.servlet.http.HttpServletResponse;
 public class UtteranceUploadServlet extends HttpServlet {
 
   private UtteranceService service = new DatastoreUtteranceService(); 
+  private StatusResponse statusResponse; 
   private String audio;
 
   @Override
@@ -54,11 +57,12 @@ public class UtteranceUploadServlet extends HttpServlet {
 
     try {
       service.saveUtterance(utterance);
-      // TO DO (ASHLEY): refactor JSON in future pr
-      response.getWriter().println("{ \"success\": true }"); 
+      String successJson = StatusResponse.convertToJson(new StatusResponse(true));
+      response.getWriter().println(successJson); 
     } catch (DatastoreFailureException e) {
-      // TO DO (ASHLEY): refactor JSON in future pr
-      response.getWriter().println("{ \"success\": false, \"error\": \"Error: Failed to upload Utterance to Datastore.\" }");
+      String failureJson = ErrorResponse.convertToJson(
+          new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore."));
+      response.getWriter().println(failureJson);
     }
   }
 

--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
@@ -57,11 +57,11 @@ public class UtteranceUploadServlet extends HttpServlet {
 
     try {
       service.saveUtterance(utterance);
-      String successJson = StatusResponse.convertToJson(new StatusResponse(true));
+      String successJson = new StatusResponse(true).toJson();
       response.getWriter().println(successJson); 
     } catch (DatastoreFailureException e) {
-      String failureJson = ErrorResponse.convertToJson(
-          new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore."));
+      String failureJson = 
+          new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore.").toJson();
       response.getWriter().println(failureJson);
     }
   }

--- a/server/src/test/java/com/google/speech/tools/voxetta/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/BlobstoreLinkServletTest.java
@@ -1,0 +1,69 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//package com.google.speech.tools.voxetta;
+
+package com.google.speech.tools.voxetta;
+
+import com.google.appengine.api.blobstore.BlobstoreService;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import javax.servlet.http.*;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** 
+* Verifies the intended behavior of BlobstoreLinkServlet.java. 
+*/
+@RunWith(JUnit4.class)
+public final class BlobstoreLinkServletTest extends Mockito {
+
+  @Test
+  public void VerifyBlobstoreLinkBehavior() throws Exception {
+    // Mock the Blobstore API service
+    BlobstoreService blobstoreService = Mockito.mock(BlobstoreService.class);
+
+    // Return the string 'url' when the mocked Blobstore service is called
+    when(blobstoreService.createUploadUrl("/upload-utterance")).thenReturn("url");
+
+    // Create a new servlet & set its Blobstore service to be the mocked service
+    BlobstoreLinkServlet servlet = new BlobstoreLinkServlet();
+    servlet.setBlobstoreService(blobstoreService);
+
+    // Mock the request and response 
+    HttpServletRequest request = mock(HttpServletRequest.class);       
+    HttpServletResponse response = mock(HttpServletResponse.class);
+
+    // Create a writer that will record the doGet function's printed text
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    // Call the doGet function now that all mocks are in place
+    servlet.doGet(request, response);
+
+    // Verify that the 'setContentType' function was truly called
+    verify(response, atLeast(1)).setContentType("text/html"); 
+
+    // Assert that the function printed the mock's retrieved 'url'
+    Assert.assertTrue(stringWriter.toString().contains("url"));
+  }
+}

--- a/server/src/test/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceServiceTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceServiceTest.java
@@ -85,7 +85,7 @@ public final class DatastoreUtteranceServiceTest extends Mockito {
   }
 
   @Test 
-  public void getAudio_BlobUploadCallbackRequestValidUpload_ReturnsKey() throws Exception {
+  public void getAudioBlob_BlobUploadCallbackRequestValidUpload_ReturnsKey() throws Exception {
     // Create a list of BlobKeys 
     BlobKey blobKey = new BlobKey("BlobKey"); 
     List<BlobKey> blobKeys = new ArrayList<>();  
@@ -97,36 +97,36 @@ public final class DatastoreUtteranceServiceTest extends Mockito {
 
     // Ensure the correct key was returned
     when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenReturn(blobs);
-    String key = service.getAudio(request);
+    String key = service.getAudioBlob(request);
     Assert.assertEquals(key, "BlobKey");
   }
 
   @Test 
-  public void getAudio_BlobUploadCallbackRequestInvalidUpload_ReturnsNull() throws Exception {
+  public void getAudioBlob_BlobUploadCallbackRequestInvalidUpload_ReturnsNull() throws Exception {
      // Create an empty map of blobs (no audio file was uploaded)
     Map<String, List<BlobKey>> blobs = new HashMap<>(); 
 
     // Ensure no key was returned
     when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenReturn(blobs);
-    Assert.assertNull(service.getAudio(request));
+    Assert.assertNull(service.getAudioBlob(request));
   }
 
   @Test (expected = IllegalStateException.class)
-  public void getAudio_NotBlobUploadCallbackRequest_ThrowsIllegalStateException() throws Exception {
+  public void getAudioBlob_NotBlobUploadCallbackRequest_ThrowsIllegalStateException() throws Exception {
     when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenThrow(IllegalStateException.class);
-    String audio = service.getAudio(request);
+    String audio = service.getAudioBlob(request);
   }
 
   @Test 
-  public void getFormUrl_BlobstoreConnectionSuccess_ReturnsUrl() throws Exception {
+  public void getAudioBlobUploadUrl_BlobstoreConnectionSuccess_ReturnsUrl() throws Exception {
     when(blobstoreService.createUploadUrl("/upload-utterance")).thenReturn("url");
-    String url = service.getFormUrl();
+    String url = service.getAudioBlobUploadUrl();
     Assert.assertEquals("url", url);
   }
 
   @Test (expected = BlobstoreFailureException.class)
-  public void getFormUrl_BlobstoreConnectionFailure_ThrowsBlobstoreFailureException() throws Exception {
+  public void getAudioBlobUploadUrl_BlobstoreConnectionFailure_ThrowsBlobstoreFailureException() throws Exception {
     when(blobstoreService.createUploadUrl("/upload-utterance")).thenThrow(BlobstoreFailureException.class);
-    String url = service.getFormUrl();
+    String url = service.getAudioBlobUploadUrl();
   }
 }

--- a/server/src/test/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceServiceTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/services/DatastoreUtteranceServiceTest.java
@@ -1,0 +1,132 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.services;
+
+import com.google.appengine.api.blobstore.BlobstoreFailureException;
+import com.google.appengine.api.blobstore.BlobstoreService;
+import com.google.appengine.api.blobstore.BlobKey;
+import com.google.appengine.api.datastore.DatastoreFailureException;
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
+import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
+import com.google.speech.tools.voxetta.data.Utterance; 
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList; 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** 
+* Verifies the intended behavior of DatastoreUtteranceService.java. 
+*/
+@RunWith(JUnit4.class)
+public final class DatastoreUtteranceServiceTest extends Mockito {
+
+  private LocalServiceTestHelper serviceHelper =
+      new LocalServiceTestHelper(new LocalDatastoreServiceTestConfig());
+  private BlobstoreService blobstoreService;
+  private DatastoreService datastoreService; 
+  private DatastoreUtteranceService service; 
+  private HttpServletRequest request; 
+
+  @Before
+  public void setUpServiceHelper() {
+    serviceHelper.setUp();
+  }
+
+  @After
+  public void tearDownServiceHelper() {
+    serviceHelper.tearDown();
+  }
+
+  @Before 
+  public void setUpMocksAndServletInstance() {
+    // Mock the Blobstore & Datastore API services
+    blobstoreService = Mockito.mock(BlobstoreService.class);
+    datastoreService = Mockito.mock(DatastoreService.class);
+
+    // Create a new Datastore Utterance Service & 
+    // set its Blobstore & Datastore services to be the mocked services
+    service = new DatastoreUtteranceService();
+    service.setBlobstoreService(blobstoreService);
+    service.setDatastoreService(datastoreService);
+
+    // Mock a HTTP request
+    request = Mockito.mock(HttpServletRequest.class);
+  }
+
+  @Test (expected = DatastoreFailureException.class)
+  public void saveUtterance_DatastoreConnectionFailure_ThrowsDatastoreFailureException() throws Exception {
+    when(datastoreService.put(any(Entity.class))).thenThrow(DatastoreFailureException.class);
+    Utterance utterance = new Utterance("audio", "userId", "promptId", "device", 100, "gender");
+    service.saveUtterance(utterance);
+  }
+
+  @Test 
+  public void getAudio_BlobUploadCallbackRequestValidUpload_ReturnsKey() throws Exception {
+    // Create a list of BlobKeys 
+    BlobKey blobKey = new BlobKey("BlobKey"); 
+    List<BlobKey> blobKeys = new ArrayList<>();  
+    blobKeys.add(blobKey); 
+
+    // Create a map of blobs
+    Map<String, List<BlobKey>> blobs = new HashMap<>(); 
+    blobs.put("audio", blobKeys);
+
+    // Ensure the correct key was returned
+    when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenReturn(blobs);
+    String key = service.getAudio(request);
+    Assert.assertEquals(key, "BlobKey");
+  }
+
+  @Test 
+  public void getAudio_BlobUploadCallbackRequestInvalidUpload_ReturnsNull() throws Exception {
+     // Create an empty map of blobs (no audio file was uploaded)
+    Map<String, List<BlobKey>> blobs = new HashMap<>(); 
+
+    // Ensure no key was returned
+    when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenReturn(blobs);
+    Assert.assertNull(service.getAudio(request));
+  }
+
+  @Test (expected = IllegalStateException.class)
+  public void getAudio_NotBlobUploadCallbackRequest_ThrowsIllegalStateException() throws Exception {
+    when(blobstoreService.getUploads(any(HttpServletRequest.class))).thenThrow(IllegalStateException.class);
+    String audio = service.getAudio(request);
+  }
+
+  @Test 
+  public void getFormUrl_BlobstoreConnectionSuccess_ReturnsUrl() throws Exception {
+    when(blobstoreService.createUploadUrl("/upload-utterance")).thenReturn("url");
+    String url = service.getFormUrl();
+    Assert.assertEquals("url", url);
+  }
+
+  @Test (expected = BlobstoreFailureException.class)
+  public void getFormUrl_BlobstoreConnectionFailure_ThrowsBlobstoreFailureException() throws Exception {
+    when(blobstoreService.createUploadUrl("/upload-utterance")).thenThrow(BlobstoreFailureException.class);
+    String url = service.getFormUrl();
+  }
+}

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -15,6 +15,9 @@
 package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.blobstore.BlobstoreFailureException;
+import com.google.speech.tools.voxetta.data.ErrorResponse;
+import com.google.speech.tools.voxetta.data.StatusResponse;
+import com.google.speech.tools.voxetta.data.UrlResponse; 
 import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.StringWriter;
 import java.io.PrintWriter;
@@ -71,7 +74,8 @@ public final class BlobstoreLinkServletTest extends Mockito {
     verify(response, atLeast(1)).setContentType("application/json"); 
 
     // Assert that the function printed a JSON indicating success containing the appropriate URL 
-    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": true, \"url\": \"url\" }"));
+    Assert.assertTrue(stringWriter.toString().contains(
+        StatusResponse.convertToJson(new UrlResponse(true, "url"))));
   }
 
   @Test
@@ -91,7 +95,7 @@ public final class BlobstoreLinkServletTest extends Mockito {
     verify(response, atLeast(1)).setContentType("application/json"); 
 
     // Assert that the function printed a JSON indicating failure containing the appropriate error message
-    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": false, " +
-        "\"error\": \"Error: Failed to upload audio file to Blobstore.\" }"));
+    Assert.assertTrue(stringWriter.toString().contains(ErrorResponse.convertToJson(
+          new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore."))));
   }
 }

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -73,9 +73,10 @@ public final class BlobstoreLinkServletTest extends Mockito {
     // Verify that the 'setContentType' function was truly called
     verify(response, atLeast(1)).setContentType("application/json"); 
 
+    System.out.println(stringWriter.toString());
+
     // Assert that the function printed a JSON indicating success containing the appropriate URL 
-    Assert.assertTrue(stringWriter.toString().contains(
-        StatusResponse.convertToJson(new UrlResponse(true, "url"))));
+    Assert.assertTrue(stringWriter.toString().contains(new UrlResponse(true, "url").toJson()));
   }
 
   @Test
@@ -95,7 +96,7 @@ public final class BlobstoreLinkServletTest extends Mockito {
     verify(response, atLeast(1)).setContentType("application/json"); 
 
     // Assert that the function printed a JSON indicating failure containing the appropriate error message
-    Assert.assertTrue(stringWriter.toString().contains(ErrorResponse.convertToJson(
-          new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore."))));
+    Assert.assertTrue(stringWriter.toString().contains(
+        new ErrorResponse(false, "Error: Failed to upload audio file to Blobstore.").toJson()));
   }
 }

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -60,7 +60,7 @@ public final class BlobstoreLinkServletTest extends Mockito {
   @Test
   public void doGet_SuccessfulUrlRetrieval_ReturnsUrl() throws Exception {
     // Return the string 'url' when the mocked Datastore Utterance Service is called 
-    when(service.getFormUrl()).thenReturn("url");
+    when(service.getAudioBlobUploadUrl()).thenReturn("url");
 
     // Create a writer that will record the doGet function's printed text
     StringWriter stringWriter = new StringWriter();
@@ -81,7 +81,7 @@ public final class BlobstoreLinkServletTest extends Mockito {
   @Test
   public void doGet_UnsuccessfulUrlRetrieval_ReturnsFailure() throws Exception {
     // Throw a BlobstoreFailureException when the mocked Datastore Utterance Service is called 
-    when(service.getFormUrl()).thenThrow(BlobstoreFailureException.class);
+    when(service.getAudioBlobUploadUrl()).thenThrow(BlobstoreFailureException.class);
 
     // Create a writer that will record the doGet function's printed text
     StringWriter stringWriter = new StringWriter();

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -73,8 +73,6 @@ public final class BlobstoreLinkServletTest extends Mockito {
     // Verify that the 'setContentType' function was truly called
     verify(response, atLeast(1)).setContentType("application/json"); 
 
-    System.out.println(stringWriter.toString());
-
     // Assert that the function printed a JSON indicating success containing the appropriate URL 
     Assert.assertTrue(stringWriter.toString().contains(new UrlResponse(true, "url").toJson()));
   }

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -15,7 +15,7 @@
 package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.blobstore.BlobstoreFailureException;
-import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
+import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import javax.servlet.http.HttpServlet;
@@ -34,7 +34,7 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public final class BlobstoreLinkServletTest extends Mockito {
 
-  private DatastoreUtteranceService service; 
+  private UtteranceService service; 
   private BlobstoreLinkServlet servlet; 
   private HttpServletRequest request; 
   private HttpServletResponse response; 
@@ -42,7 +42,7 @@ public final class BlobstoreLinkServletTest extends Mockito {
   @Before
   public void setUpMocksAndServletInstance() {
     // Mock the Datastore Utterance Service
-    service = Mockito.mock(DatastoreUtteranceService.class);
+    service = Mockito.mock(UtteranceService.class);
 
     // Create a new Blobstore Link Servlet & set its service 
     // to be the mocked Datastore Utterance Service

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/BlobstoreLinkServletTest.java
@@ -1,0 +1,97 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.servlets;
+
+import com.google.appengine.api.blobstore.BlobstoreFailureException;
+import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Assert;
+import org.junit.Before; 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** 
+ * Verifies the intended behavior of BlobstoreLinkServlet.java. 
+ */
+@RunWith(JUnit4.class)
+public final class BlobstoreLinkServletTest extends Mockito {
+
+  private DatastoreUtteranceService service; 
+  private BlobstoreLinkServlet servlet; 
+  private HttpServletRequest request; 
+  private HttpServletResponse response; 
+
+  @Before
+  public void setUpMocksAndServletInstance() {
+    // Mock the Datastore Utterance Service
+    service = Mockito.mock(DatastoreUtteranceService.class);
+
+    // Create a new Blobstore Link Servlet & set its service 
+    // to be the mocked Datastore Utterance Service
+    servlet = new BlobstoreLinkServlet();
+    servlet.setService(service);
+
+    // Mock the request and response 
+    request = mock(HttpServletRequest.class);       
+    response = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  public void doGet_SuccessfulUrlRetrieval_ReturnsUrl() throws Exception {
+    // Return the string 'url' when the mocked Datastore Utterance Service is called 
+    when(service.getFormUrl()).thenReturn("url");
+
+    // Create a writer that will record the doGet function's printed text
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+    
+    // Call the doGet function now that all mocks are in place
+    servlet.doGet(request, response);
+
+    // Verify that the 'setContentType' function was truly called
+    verify(response, atLeast(1)).setContentType("application/json"); 
+
+    // Assert that the function printed a JSON indicating success containing the appropriate URL 
+    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": true, \"url\": \"url\" }"));
+  }
+
+  @Test
+  public void doGet_UnsuccessfulUrlRetrieval_ReturnsFailure() throws Exception {
+    // Throw a BlobstoreFailureException when the mocked Datastore Utterance Service is called 
+    when(service.getFormUrl()).thenThrow(BlobstoreFailureException.class);
+
+    // Create a writer that will record the doGet function's printed text
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+    
+    // Call the doGet function now that all mocks are in place
+    servlet.doGet(request, response);
+
+    // Verify that the 'setContentType' function was truly called
+    verify(response, atLeast(1)).setContentType("application/json"); 
+
+    // Assert that the function printed a JSON indicating failure containing the appropriate error message
+    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": false, " +
+        "\"error\": \"Error: Failed to upload audio file to Blobstore.\" }"));
+  }
+}

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -16,7 +16,7 @@ package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.datastore.DatastoreFailureException;
 import com.google.speech.tools.voxetta.data.Utterance; 
-import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
+import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 import javax.servlet.http.HttpServlet;
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 @RunWith(JUnit4.class)
 public final class UtteranceUploadServletTest extends Mockito {
 
-  private DatastoreUtteranceService service; 
+  private UtteranceService service; 
   private UtteranceUploadServlet servlet; 
   private HttpServletRequest request; 
   private HttpServletResponse response;
@@ -45,7 +45,7 @@ public final class UtteranceUploadServletTest extends Mockito {
   @Before
   public void setUpMocksAndServletInstance() {
     // Mock the Datastore Utterance Service
-    service = Mockito.mock(DatastoreUtteranceService.class);
+    service = Mockito.mock(UtteranceService.class);
 
     // Create a new Blobstore Link Servlet & set its service 
     // to be the mocked Datastore Utterance Service

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -78,7 +78,7 @@ public final class UtteranceUploadServletTest extends Mockito {
     System.out.println(stringWriter.toString());
 
     // Assert that the function printed a JSON indicating success
-    Assert.assertTrue(stringWriter.toString().contains(StatusResponse.convertToJson(new StatusResponse(true))));
+    Assert.assertTrue(stringWriter.toString().contains(new StatusResponse(true).toJson()));
   }
 
   @Test
@@ -102,6 +102,6 @@ public final class UtteranceUploadServletTest extends Mockito {
 
     // Assert that the function printed a JSON indicating failure containing the appropriate error message
     Assert.assertTrue(stringWriter.toString().contains(
-        StatusResponse.convertToJson(new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore."))));
+        new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore.").toJson()));
   }
 }

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -1,0 +1,103 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.speech.tools.voxetta.servlets;
+
+import com.google.appengine.api.datastore.DatastoreFailureException;
+import com.google.speech.tools.voxetta.data.Utterance; 
+import com.google.speech.tools.voxetta.services.DatastoreUtteranceService;
+import java.io.StringWriter;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/**  
+ * Verifies the intended behavior of UtteranceUploadServlet.java. 
+ */
+@RunWith(JUnit4.class)
+public final class UtteranceUploadServletTest extends Mockito {
+
+  private DatastoreUtteranceService service; 
+  private UtteranceUploadServlet servlet; 
+  private HttpServletRequest request; 
+  private HttpServletResponse response;
+  private Utterance utterance; 
+
+  @Before
+  public void setUpMocksAndServletInstance() {
+    // Mock the Datastore Utterance Service
+    service = Mockito.mock(DatastoreUtteranceService.class);
+
+    // Create a new Blobstore Link Servlet & set its service 
+    // to be the mocked Datastore Utterance Service
+    servlet = new UtteranceUploadServlet();
+    servlet.setService(service);
+
+    // Mock the request and response 
+    request = mock(HttpServletRequest.class);       
+    response = mock(HttpServletResponse.class);
+  }
+
+  @Test
+  public void doPost_SuccessfulDatastoreUpload_ReturnsSuccess() throws Exception {
+    // Return the string 'audioBlobKey' when the mocked Datastore Utterance Service is called
+    when(service.getAudio(request)).thenReturn("audioBlobKey");
+
+    // Create a writer that will record the doPost function's printed text
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    // Call the doPost function now that all mocks are in place
+    servlet.doPost(request, response);
+
+    // Verify that the 'setContentType' function was truly called
+    verify(response, atLeast(1)).setContentType("application/json"); 
+
+    // Assert that the function printed a JSON indicating success
+    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": true }"));
+  }
+
+  @Test
+  public void doPost_UnsuccessfulDatastoreUpload_ReturnsFailure() throws Exception {
+    // Return the string 'audioBlobKey' when the mocked Datastore Utterance Service is called
+    when(service.getAudio(request)).thenReturn("audioBlobKey");
+
+    // Throw a DatastoreFailureException when the saveUtterance() method is called
+    Mockito.doThrow(DatastoreFailureException.class).when(service).saveUtterance(any(Utterance.class));
+
+    // Create a writer that will record the doPost function's printed text
+    StringWriter stringWriter = new StringWriter();
+    PrintWriter printWriter = new PrintWriter(stringWriter);
+    when(response.getWriter()).thenReturn(printWriter);
+
+    // Call the doPost function now that all mocks are in place
+    servlet.doPost(request, response);
+
+    // Verify that the 'setContentType' function was truly called
+    verify(response, atLeast(1)).setContentType("application/json"); 
+
+    // Assert that the function printed a JSON indicating failure containing the appropriate error message
+    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": false, "
+    + "\"error\": \"Error: Failed to upload Utterance to Datastore.\" }"));
+  }
+}

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -15,7 +15,9 @@
 package com.google.speech.tools.voxetta.servlets;
 
 import com.google.appengine.api.datastore.DatastoreFailureException;
-import com.google.speech.tools.voxetta.data.Utterance; 
+import com.google.speech.tools.voxetta.data.Utterance;
+import com.google.speech.tools.voxetta.data.ErrorResponse; 
+import com.google.speech.tools.voxetta.data.StatusResponse;
 import com.google.speech.tools.voxetta.services.UtteranceService;
 import java.io.StringWriter;
 import java.io.PrintWriter;
@@ -73,8 +75,10 @@ public final class UtteranceUploadServletTest extends Mockito {
     // Verify that the 'setContentType' function was truly called
     verify(response, atLeast(1)).setContentType("application/json"); 
 
+    System.out.println(stringWriter.toString());
+
     // Assert that the function printed a JSON indicating success
-    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": true }"));
+    Assert.assertTrue(stringWriter.toString().contains(StatusResponse.convertToJson(new StatusResponse(true))));
   }
 
   @Test
@@ -97,7 +101,7 @@ public final class UtteranceUploadServletTest extends Mockito {
     verify(response, atLeast(1)).setContentType("application/json"); 
 
     // Assert that the function printed a JSON indicating failure containing the appropriate error message
-    Assert.assertTrue(stringWriter.toString().contains("{ \"success\": false, "
-    + "\"error\": \"Error: Failed to upload Utterance to Datastore.\" }"));
+    Assert.assertTrue(stringWriter.toString().contains(
+        StatusResponse.convertToJson(new ErrorResponse(false, "Error: Failed to upload Utterance to Datastore."))));
   }
 }

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -62,7 +62,7 @@ public final class UtteranceUploadServletTest extends Mockito {
   @Test
   public void doPost_SuccessfulDatastoreUpload_ReturnsSuccess() throws Exception {
     // Return the string 'audioBlobKey' when the mocked Datastore Utterance Service is called
-    when(service.getAudio(request)).thenReturn("audioBlobKey");
+    when(service.getAudioBlob(request)).thenReturn("audioBlobKey");
 
     // Create a writer that will record the doPost function's printed text
     StringWriter stringWriter = new StringWriter();
@@ -84,7 +84,7 @@ public final class UtteranceUploadServletTest extends Mockito {
   @Test
   public void doPost_UnsuccessfulDatastoreUpload_ReturnsFailure() throws Exception {
     // Return the string 'audioBlobKey' when the mocked Datastore Utterance Service is called
-    when(service.getAudio(request)).thenReturn("audioBlobKey");
+    when(service.getAudioBlob(request)).thenReturn("audioBlobKey");
 
     // Throw a DatastoreFailureException when the saveUtterance() method is called
     Mockito.doThrow(DatastoreFailureException.class).when(service).saveUtterance(any(Utterance.class));


### PR DESCRIPTION
I added three Response objects: StatusResponse, ErrorResponse, & UrlResponse (the latter two which extend StatusResponse). Instead of having the Utterance servlets return raw JSON, I instead return a StatusResponse object that has been converted to JSON via GSON. I updated the servlet testing files to reflect this update. 