### PR TITLE
update mockito to 2.27.0 to support JDK 11

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -69,7 +69,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.17.0</version>
+            <version>2.27.0</version>
             <scope>test</scope>
         </dependency>
 	</dependencies>


### PR DESCRIPTION
So apparently DIYing your own dev environment is so unsupported within google that after 45 minutes techstop literally didn't know how to help me instasll JDK 8 on my cloudtop... BUT I found that our mockito was outdated, and updating it within pom.xml lets tests run on both JDK 8 and JDK 11.

I tested this update on both my JDK 11 cloudtop and my JDK 8 cloudshell, and both seem to work fine. 