### PR TITLE
Store User Info in Datastore

### DIFF
--- a/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
+++ b/server/src/main/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServlet.java
@@ -48,11 +48,11 @@ public class UtteranceUploadServlet extends HttpServlet {
     // Create and save Utterance to Datastore
     Utterance utterance = new Utterance.UtteranceBuilder()
       .setAudio(audio)
-      .setUserId("USERID")
+      .setUserId(request.getParameter("userId"))
       .setPromptId("PROMPTID")
-      .setDevice("DEVICE")
-      .setAge(100)
-      .setGender("GENDER")
+      .setDevice(request.getParameter("deviceType"))
+      .setAge(Integer.parseInt(request.getParameter("userAge")))
+      .setGender(request.getParameter("gender"))
       .build();
 
     try {

--- a/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
+++ b/server/src/test/java/com/google/speech/tools/voxetta/servlets/UtteranceUploadServletTest.java
@@ -35,6 +35,7 @@ import org.mockito.Mockito;
 /**  
  * Verifies the intended behavior of UtteranceUploadServlet.java. 
  */
+ 
 @RunWith(JUnit4.class)
 public final class UtteranceUploadServletTest extends Mockito {
 
@@ -57,6 +58,12 @@ public final class UtteranceUploadServletTest extends Mockito {
     // Mock the request and response 
     request = mock(HttpServletRequest.class);       
     response = mock(HttpServletResponse.class);
+
+    // Return example data when request parameters are fetched
+    when(request.getParameter("userId")).thenReturn("123456");
+    when(request.getParameter("gender")).thenReturn("Female");
+    when(request.getParameter("userAge")).thenReturn("100");
+    when(request.getParameter("deviceType")).thenReturn("Pixelbook");
   }
 
   @Test


### PR DESCRIPTION
This pull request features an Utterance backend update. The Utterance Upload Servlet will now parse various user-related pieces of information from the POST request and store it alongside the audio file (giving meaning to what was originally "FILLER"). It also includes an update to the Utterance Upload Servlet Test file to reflect these changes.