### PR TITLE
Manual Reupload

### DIFF
--- a/ui/jasmine_test/spec/helpers/jsdom_init.js
+++ b/ui/jasmine_test/spec/helpers/jsdom_init.js
@@ -23,6 +23,7 @@ const dom = new JSDOM('<html><body></body></html>');
 global.document = dom.window.document;
 global.window = dom.window;
 global.window.alert = () => {};
+global.window.URL.revokeObjectURL = () => {};
 global.navigator = dom.window.navigator;
 global.navigator.mediaDevices = {getUserMedia: () => {}};
 global.MediaRecorder = StubMediaRecorder;

--- a/ui/src/StateContainer.js
+++ b/ui/src/StateContainer.js
@@ -213,7 +213,7 @@ export class StateContainer extends LitElement {
 
     handleAddToast(e) {
         this.toast = e.detail.message;
-        this.reupload = e.detail.reupload; 
+        this.icon = e.detail.icon; 
     }
 
     handleClearToast() {
@@ -228,7 +228,7 @@ export class StateContainer extends LitElement {
         return html` 
             <vox-toast 
                 message="${this.toast}"
-                ?reupload="${this.reupload}"
+                icon="${this.icon}"
             >
             </vox-toast> `;
     }
@@ -283,7 +283,7 @@ export class StateContainer extends LitElement {
             @enter-form="${this.handleEnterForm}"
             @exit-form="${this.handleExitForm}"
             @first-access-over="${this.handleFirstAccessOver}"
-            @reupload-audio="${this.handleReuploadAudio}"
+            @toast-autorenew="${this.handleReuploadAudio}"
             @save-audio="${this.handleSaveAudio}"
             @skip-prompt="${this.handleSkipPrompt}"
             @update-collection-state=${this.updateCollectionState}

--- a/ui/src/StateContainer.js
+++ b/ui/src/StateContainer.js
@@ -65,6 +65,7 @@ export class StateContainer extends LitElement {
 
         this.country = undefined;
         this.loginCompleted = false;
+        this.reupload = false; 
         this.userInfoPresent = false;
         this.view = Views.COUNTRY_SELECTION;
         this.viewShadowRoot = undefined;
@@ -202,8 +203,8 @@ export class StateContainer extends LitElement {
     }
 
     /**
-     * Handles user form updating
-     * @param {Event} e object dispatched from user form
+     * Handles user form updating.
+     * @param {Event} e Object dispatched from the user form.
      */
     handleUserInfoUpdate(e) {
         this.updateUserInformation(e.detail.userInfo);
@@ -212,6 +213,7 @@ export class StateContainer extends LitElement {
 
     handleAddToast(e) {
         this.toast = e.detail.message;
+        this.reupload = e.detail.reupload; 
     }
 
     handleClearToast() {
@@ -222,7 +224,13 @@ export class StateContainer extends LitElement {
         if (!this.toast) {
             return html``;
         }
-        return html` <vox-toast message="${this.toast}"></vox-toast> `;
+ 
+        return html` 
+            <vox-toast 
+                message="${this.toast}"
+                ?reupload="${this.reupload}"
+            >
+            </vox-toast> `;
     }
 
     /**
@@ -231,6 +239,27 @@ export class StateContainer extends LitElement {
      */
     updateCollectionState(e) {
         this.collectionState = e.detail.state;
+    }
+
+    /**
+     * Saves the current audio file locally.
+     * @param {Event} e Object dispatched from the record button.
+     */
+    handleSaveAudio(e) {
+        this.latestAudio = e.detail.audio; 
+    }
+
+    /**
+     * Attempts to reupload the latest audio file.
+     */
+    handleReuploadAudio() {
+        const recordComponent = this.viewShadowRoot.querySelector(
+            'vox-recording-section'
+        );
+        const buttonComponent = recordComponent.shadowRoot.querySelector(
+            'vox-record-button'
+        );
+        buttonComponent.uploadAudio(this.latestAudio);
     }
 
     /**
@@ -254,12 +283,13 @@ export class StateContainer extends LitElement {
             @enter-form="${this.handleEnterForm}"
             @exit-form="${this.handleExitForm}"
             @first-access-over="${this.handleFirstAccessOver}"
+            @reupload-audio="${this.handleReuploadAudio}"
+            @save-audio="${this.handleSaveAudio}"
             @skip-prompt="${this.handleSkipPrompt}"
             @update-collection-state=${this.updateCollectionState}
             @update-user-info="${this.handleUserInfoUpdate}"
             @update-wave="${this.handleUpdateWave}"
         >
-            ${this.renderToast()}
             <vox-view-container
                 .audioStream=${this.audioStream}
                 .collectionState=${this.collectionState}
@@ -271,6 +301,7 @@ export class StateContainer extends LitElement {
                 ?login-completed=${this.loginCompleted}
             >
             </vox-view-container>
+            ${this.renderToast()}
         </div>`;
     }
 }

--- a/ui/src/components/RecordButton.js
+++ b/ui/src/components/RecordButton.js
@@ -136,16 +136,7 @@ export class RecordButton extends LitElement {
             return;
         }
 
-        // Attempt to upload it
-        if (audio.recordingUrl) {
-            try {
-                const resp = await this.utteranceService.saveAudio(audio);
-                if (!resp) throw new Error('Failed to upload utterance');
-            } catch (e) {
-                // If upload failed, pivot to upload error collection state
-                this.dispatchCollectionState(CollectionStates.UPLOAD_ERROR);
-            }
-        }
+        this.uploadAudio(audio);
     }
 
     /**
@@ -160,10 +151,12 @@ export class RecordButton extends LitElement {
 
             if (!response) {
                 dispatchRetryToast(this, `Audio failed to upload. Retry?`);
+                this.dispatchCollectionState(CollectionStates.UPLOAD_ERROR);
             }
 
         // Dispatch transition to next prompt.
         this.dispatchCollectionState(CollectionStates.TRANSITIONING);
+        }
     }
 
     /**

--- a/ui/src/components/RecordButton.js
+++ b/ui/src/components/RecordButton.js
@@ -20,6 +20,7 @@ import {AudioRecorder} from '../utils/AudioRecorder';
 import {UtteranceApiService} from '../utils/UtteranceApiService';
 import {QualityControl} from '../utils/QualityControl';
 import {dispatchErrorToast} from '../utils/ToastUtils.js';
+import {dispatchRetryToast} from '../utils/ToastUtils.js';
 import {CollectionStates} from '../utils/CollectionStatesEnum';
 
 import style from '../styles/components/RecordButton.css.js';
@@ -121,7 +122,7 @@ export class RecordButton extends LitElement {
             const response = await this.utteranceService.saveAudio(audio);
 
             if (!response) {
-                dispatchErrorToast(this, `Audio failed to upload. Retry?`, true);
+                dispatchRetryToast(this, `Audio failed to upload. Retry?`);
             }
         }
         this.handleFinish();

--- a/ui/src/components/feedback/Toast.js
+++ b/ui/src/components/feedback/Toast.js
@@ -22,13 +22,13 @@ import style from '../../styles/components/feedback/Toast.css.js';
 import * as ToastUtils from '../../utils/ToastUtils.js';
 
 /**
- * Component that displays error messages as a "toast" at the top of the app view.
+ * Component that displays error messages as a "toast" at the bottom of the app view.
  */
 export class Toast extends LitElement {
     static get properties() {
         return {
             message: {type: String},
-            reupload: {type: Boolean},
+            icon: {type: String},
         };
     }
 
@@ -36,21 +36,20 @@ export class Toast extends LitElement {
         return style;
     }
 
-    dispatchClearToast() {
-        ToastUtils.clearToast(this);
-    }
-
     /**
-     * Emits an event that results in an attempt to manually
-     * resubmit the last failed audio upload.
+     * Clears the toast and emits an event to handle the the 
+     * user's toast interaction properly.
      */
-    handleReuploadAudio() {
-        const event = new CustomEvent('reupload-audio', {
-            bubbles: true,
-            composed: true,
-        });
-        this.dispatchEvent(event);
+    handleToastInteraction() {
         ToastUtils.clearToast(this);
+
+        if (this.icon !== 'clear') {
+            const event = new CustomEvent('toast-' + this.icon, {
+                bubbles: true,
+                composed: true,
+            });
+            this.dispatchEvent(event);
+        }
     }
 
     render() {
@@ -58,19 +57,9 @@ export class Toast extends LitElement {
             <div class="toast">
                 <p>${this.message}</p>
 
-                <!-- Display the reupload button if it is a reupload toast -->
-                ${this.reupload
-                    ? html`
-                        <mwc-icon-button
-                            icon="autorenew"
-                            @click=${this.handleReuploadAudio}
-                        ></mwc-icon-button>
-                      `
-                    : html``}
-
                 <mwc-icon-button
-                    icon="clear"
-                    @click=${this.dispatchClearToast}
+                    icon="${this.icon}"
+                    @click=${this.handleToastInteraction}
                 ></mwc-icon-button>
             </div>
         `;

--- a/ui/src/components/feedback/Toast.js
+++ b/ui/src/components/feedback/Toast.js
@@ -28,6 +28,7 @@ export class Toast extends LitElement {
     static get properties() {
         return {
             message: {type: String},
+            reupload: {type: Boolean},
         };
     }
 
@@ -39,10 +40,33 @@ export class Toast extends LitElement {
         ToastUtils.clearToast(this);
     }
 
+    /**
+     * Emits an event that results in an attempt to manually
+     * resubmit the last failed audio upload.
+     */
+    handleReuploadAudio() {
+        const event = new CustomEvent('reupload-audio', {
+            bubbles: true,
+            composed: true,
+        });
+        this.dispatchEvent(event);
+        ToastUtils.clearToast(this);
+    }
+
     render() {
         return html`
             <div class="toast">
                 <p>${this.message}</p>
+
+                <!-- Display the reupload button if it is a reupload toast -->
+                ${this.reupload
+                    ? html`
+                        <mwc-icon-button
+                            icon="autorenew"
+                            @click=${this.handleReuploadAudio}
+                        ></mwc-icon-button>
+                      `
+                    : html``}
 
                 <mwc-icon-button
                     icon="clear"

--- a/ui/src/utils/ToastUtils.js
+++ b/ui/src/utils/ToastUtils.js
@@ -19,10 +19,11 @@
  * @param {LitElement} e Element to dispatch event from (usually `this`).
  * @param {*} message Message to display in error toast template.
  */
-const dispatchErrorToast = (elem, message, reupload=false) => {
+const dispatchErrorToast = (elem, message) => {
     const toastEvent = new CustomEvent('add-toast', {
         detail: {
             message,
+            icon: 'clear',
         },
         bubbles: true,
         composed: true,
@@ -40,7 +41,7 @@ const dispatchRetryToast = (elem, message) => {
     const toastEvent = new CustomEvent('add-toast', {
         detail: {
             message,
-            reupload: true,
+            icon: 'autorenew',
         },
         bubbles: true,
         composed: true,

--- a/ui/src/utils/ToastUtils.js
+++ b/ui/src/utils/ToastUtils.js
@@ -15,16 +15,32 @@
  */
 
 /**
- * Dispatches an error toast event from the element it is called from
- * @param {LitElement} e Element to dispatch event from (usually `this`)
- * @param {*} message Message to display in error toast template
- * @param {Boolean} reupload Denotes if the toast is a reuploading toast
+ * Dispatches an error toast event from the element it is called from.
+ * @param {LitElement} e Element to dispatch event from (usually `this`).
+ * @param {*} message Message to display in error toast template.
  */
 const dispatchErrorToast = (elem, message, reupload=false) => {
     const toastEvent = new CustomEvent('add-toast', {
         detail: {
             message,
-            reupload,
+        },
+        bubbles: true,
+        composed: true,
+    });
+
+    elem.dispatchEvent(toastEvent);
+};
+
+/**
+ * Dispatches a retry toast event from the element it is called from.
+ * @param {LitElement} e Element to dispatch event from (usually `this`).
+ * @param {*} message Message to display in error toast template.
+ */
+const dispatchRetryToast = (elem, message) => {
+    const toastEvent = new CustomEvent('add-toast', {
+        detail: {
+            message,
+            reupload: true,
         },
         bubbles: true,
         composed: true,
@@ -47,4 +63,4 @@ const clearToast = (elem) => {
     elem.dispatchEvent(toastEvent);
 };
 
-export {dispatchErrorToast, clearToast};
+export {dispatchErrorToast, dispatchRetryToast, clearToast};

--- a/ui/src/utils/ToastUtils.js
+++ b/ui/src/utils/ToastUtils.js
@@ -18,11 +18,13 @@
  * Dispatches an error toast event from the element it is called from
  * @param {LitElement} e Element to dispatch event from (usually `this`)
  * @param {*} message Message to display in error toast template
+ * @param {Boolean} reupload Denotes if the toast is a reuploading toast
  */
-const dispatchErrorToast = (elem, message) => {
+const dispatchErrorToast = (elem, message, reupload=false) => {
     const toastEvent = new CustomEvent('add-toast', {
         detail: {
             message,
+            reupload,
         },
         bubbles: true,
         composed: true,

--- a/ui/src/utils/UtteranceApiService.js
+++ b/ui/src/utils/UtteranceApiService.js
@@ -54,7 +54,11 @@ export class UtteranceApiService {
         }
 
         const query = await response.json();
-        return query.success; 
+        if (query.success) {
+            window.URL.revokeObjectURL(audio.url)
+            return true;
+        } 
+        return false; 
     }
 
     /**

--- a/ui/src/utils/UtteranceApiService.js
+++ b/ui/src/utils/UtteranceApiService.js
@@ -55,7 +55,7 @@ export class UtteranceApiService {
 
         const query = await response.json();
         if (query.success) {
-            window.URL.revokeObjectURL(audio.url)
+            window.URL.revokeObjectURL(audio.url);
             return true;
         } 
         return false; 

--- a/ui/src/utils/UtteranceApiService.js
+++ b/ui/src/utils/UtteranceApiService.js
@@ -32,28 +32,29 @@ export class UtteranceApiService {
     /**
      * Save a recorded audio file to an external database.
      * @param {Object} audio - An object containing an audio Blob and its corresponding URL.
-     * @returns {Boolean} Indicates whether or not an audio file was successfully uploaded.
+     * @return {Boolean} Indicates whether or not an audio file was successfully uploaded.
      */
     async saveAudio(audio) {
+
         // Get Blobstore URL & Form Data
         const url = await this.getUploadUrl();
-
-        if (!url) {
-            return false;
-        }
+        if (!url) return false;
 
         this.getFormData(audio);
 
-        const response = await fetch(url, {
-            method: 'POST',
-            body: this.formData,
-        });
-        const query = await response.json();
-
-        if (!query.success) {
-            return false;
+        // Attempt to save audio file
+        let response; 
+        try {
+            response = await fetch(url, {
+                method: 'POST',
+                body: this.formData,
+            });
+        } catch (e) { 
+            return false; 
         }
-        return true;
+
+        const query = await response.json();
+        return query.success; 
     }
 
     /**
@@ -71,16 +72,20 @@ export class UtteranceApiService {
 
     /**
      * Retrieve and return a Blobstore upload link.
-     * @returns {String} A Blobstore URL
+     * @returns {String} A Blobstore URL, or null if a 
+     * URL was not able to be retrieved.
      */
     async getUploadUrl() {
-        const response = await fetch('/blobstore-utterance-upload-link');
-        const query = await response.json();
-
-        if (query.success) {
-            return query.url;
+        let response; 
+        try {
+            response = await fetch('/blobstore-utterance-upload-link');
+        } catch (e) {
+            return null;
         }
+        
+        const query = await response.json();
+        if (query.success) return query.url;
 
-        return null;
+        return null; 
     }
 }


### PR DESCRIPTION
This pull request features the manual re-uploading feature. To accomplish this feature, I utilized the existing Toast feature and audio saving functionality, refactoring where needed. Now, when the user has internet connectivity issues & their audio file does not upload, they will be presented with a reupload toast. Upon clicking the 'refresh' button, the latest audio file will attempt to reupload. If successful, the toast disappears. Otherwise, it remains.

UX questions for the team:
1) Should the reupload toast have an exit option?
2) Should the user be prevented from recording until their failed file is successfully uploaded?

![image](https://user-images.githubusercontent.com/48967754/89351177-76c47a80-d67f-11ea-989f-f193c81d24af.png)

